### PR TITLE
Use Supabase storage for uploaded images

### DIFF
--- a/backend/src/controllers/clinicSettingsController/ImagesController.ts
+++ b/backend/src/controllers/clinicSettingsController/ImagesController.ts
@@ -1,20 +1,6 @@
 import { Request, Response } from 'express';
 import { supabase } from '../../supabaseClient';
-import fs from 'fs/promises';
-import path from 'path';
-
-const UPLOADS_SERVER_PATH = path.join(__dirname, '..', '..', 'uploads');
-const UPLOADS_PUBLIC_PATH = '/uploads';
-
-function publicPathToAbsoluteServerPath(publicPath: string): string | null {
-  if (!publicPath || !publicPath.startsWith(UPLOADS_PUBLIC_PATH)) return null;
-  const filename = publicPath.substring(UPLOADS_PUBLIC_PATH.length + 1);
-  return path.join(UPLOADS_SERVER_PATH, filename);
-}
-
-async function deleteFileFromServer(filePathOnServer: string): Promise<void> {
-  try { await fs.unlink(filePathOnServer); } catch (e) {}
-}
+import { removeImage } from '../../services/storageService';
 
 export const update = async (req: Request, res: Response) => {
   const { removeCoverImage, existingGalleryUrls, galleryUrlsToRemove, clinicId } = req.body;
@@ -25,7 +11,6 @@ export const update = async (req: Request, res: Response) => {
   const newGalleryImageFiles = files?.galleryImages || [];
 
   try {
-    // Busca configurações atuais
     const { data: currentSettingsArr, error: settingsError } = await supabase
       .from('clinic_settings')
       .select('*')
@@ -37,28 +22,35 @@ export const update = async (req: Request, res: Response) => {
 
     let newCoverImageUrl: string | null | undefined = currentSettings?.cover_image_url;
     if (removeCoverImage === 'true' && currentSettings?.cover_image_url) {
-      const oldCoverPathAbsolute = publicPathToAbsoluteServerPath(currentSettings.cover_image_url);
-      if (oldCoverPathAbsolute) await deleteFileFromServer(oldCoverPathAbsolute);
+      await removeImage(currentSettings.cover_image_url);
       newCoverImageUrl = null;
     }
     if (newCoverImageFile) {
-      if (currentSettings?.cover_image_url && currentSettings.cover_image_url !== `${UPLOADS_PUBLIC_PATH}/${newCoverImageFile.filename}`) {
-        const oldCoverPathAbsolute = publicPathToAbsoluteServerPath(currentSettings.cover_image_url);
-        if (oldCoverPathAbsolute) await deleteFileFromServer(oldCoverPathAbsolute);
+      if (currentSettings?.cover_image_url && currentSettings.cover_image_url !== newCoverImageFile.filename) {
+        await removeImage(currentSettings.cover_image_url);
       }
-      newCoverImageUrl = `${UPLOADS_PUBLIC_PATH}/${newCoverImageFile.filename}`;
+      newCoverImageUrl = newCoverImageFile.filename;
     }
 
     let currentGalleryUrls: string[] = [];
     if (currentSettings?.gallery_image_urls) {
-      try { currentGalleryUrls = Array.isArray(currentSettings.gallery_image_urls) ? currentSettings.gallery_image_urls : JSON.parse(currentSettings.gallery_image_urls); } catch { currentGalleryUrls = []; }
+      try {
+        currentGalleryUrls = Array.isArray(currentSettings.gallery_image_urls)
+          ? currentSettings.gallery_image_urls
+          : JSON.parse(currentSettings.gallery_image_urls);
+      } catch {
+        currentGalleryUrls = [];
+      }
     }
-    const galleryUrlsToRemoveArr: string[] = galleryUrlsToRemove ? (typeof galleryUrlsToRemove === "string" ? JSON.parse(galleryUrlsToRemove) : galleryUrlsToRemove) : [];
-    const existingGalleryUrlsArr: string[] = existingGalleryUrls ? (typeof existingGalleryUrls === "string" ? JSON.parse(existingGalleryUrls) : existingGalleryUrls) : [];
+    const galleryUrlsToRemoveArr: string[] = galleryUrlsToRemove
+      ? (typeof galleryUrlsToRemove === 'string' ? JSON.parse(galleryUrlsToRemove) : galleryUrlsToRemove)
+      : [];
+    const existingGalleryUrlsArr: string[] = existingGalleryUrls
+      ? (typeof existingGalleryUrls === 'string' ? JSON.parse(existingGalleryUrls) : existingGalleryUrls)
+      : [];
     for (const urlToRemove of galleryUrlsToRemoveArr) {
       if (currentGalleryUrls.includes(urlToRemove)) {
-        const filePathAbsolute = publicPathToAbsoluteServerPath(urlToRemove);
-        if (filePathAbsolute) await deleteFileFromServer(filePathAbsolute);
+        await removeImage(urlToRemove);
       }
     }
     const finalGalleryUrlsSet = new Set<string>();
@@ -66,7 +58,7 @@ export const update = async (req: Request, res: Response) => {
       if (!galleryUrlsToRemoveArr.includes(url)) finalGalleryUrlsSet.add(url);
     });
     newGalleryImageFiles.forEach(file => {
-      finalGalleryUrlsSet.add(`${UPLOADS_PUBLIC_PATH}/${file.filename}`);
+      finalGalleryUrlsSet.add(file.filename);
     });
     const updatedGalleryUrls = Array.from(finalGalleryUrlsSet);
 

--- a/backend/src/controllers/patientController.ts
+++ b/backend/src/controllers/patientController.ts
@@ -224,7 +224,7 @@ export const createPatient = async (req: Request, res: Response) => {
 
   let photo: string | null = null;
   if ((req as any).file) {
-    photo = `/uploads/${(req as any).file.filename}`;
+    photo = (req as any).file.filename;
   } else if (req.body.photo) {
     photo = req.body.photo;
   }
@@ -282,7 +282,7 @@ export const updatePatient = async (
   const { name, email, phone, birthdate, address, city, state, zipcode } = req.body;
   let photo = req.body.photo || null;
   if ((req as any).file) {
-    photo = `/uploads/${(req as any).file.filename}`;
+    photo = (req as any).file.filename;
   }
 
   const updatedFields: Partial<Patient> = {

--- a/backend/src/controllers/patientProceduresController.ts
+++ b/backend/src/controllers/patientProceduresController.ts
@@ -151,7 +151,7 @@ export async function uploadProcedureImage(req: Request, res: Response) {
       return res.status(400).json({ error: "Nenhum arquivo enviado." });
     }
 
-    const fileUrl = `/uploads/${req.file.filename}`;
+    const fileUrl = req.file.filename;
 
     // Inserimos usando 'filename' (nome real da coluna no banco).
     const { data: imgArr, error } = await supabase

--- a/backend/src/middleware/uploadMiddleware.ts
+++ b/backend/src/middleware/uploadMiddleware.ts
@@ -1,38 +1,8 @@
-import multer, { FileFilterCallback, StorageEngine } from 'multer';
-import path from 'path';
-import fs from 'fs';
-import { Request } from 'express';
+import multer, { FileFilterCallback } from 'multer';
+import { Request, Response, NextFunction } from 'express';
+import { uploadImageFromBuffer } from '../services/storageService';
 
-// Diretório para uploads
-const UPLOADS_FOLDER = path.resolve(__dirname, '..', '..', 'uploads');
-
-// Garante que a pasta de uploads exista
-const ensureUploadsFolderExists = () => {
-  if (!fs.existsSync(UPLOADS_FOLDER)) {
-    try {
-      fs.mkdirSync(UPLOADS_FOLDER, { recursive: true });
-      console.log(`Pasta de uploads criada em: ${UPLOADS_FOLDER}`);
-    } catch (err) {
-      console.error(`Erro ao criar a pasta de uploads (${UPLOADS_FOLDER}):`, err);
-      throw new Error('Falha ao criar diretório de uploads necessário.');
-    }
-  }
-};
-
-ensureUploadsFolderExists();
-
-const storage: StorageEngine = multer.diskStorage({
-  destination: function (_req: Request, _file: Express.Multer.File, cb) {
-    cb(null, UPLOADS_FOLDER);
-  },
-  filename: function (_req: Request, file: Express.Multer.File, cb) {
-    // Padrão photo-<timestamp>-<random>.<extensão> para profissionais
-    const ext = path.extname(file.originalname) || '.png';
-    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    const prefix = file.fieldname === 'photo' ? 'photo' : file.fieldname;
-    cb(null, `${prefix}-${unique}${ext}`);
-  }
-});
+const storage = multer.memoryStorage();
 
 const fileFilter = (_req: Request, file: Express.Multer.File, cb: FileFilterCallback) => {
   if (file.mimetype.startsWith('image/')) {
@@ -42,27 +12,62 @@ const fileFilter = (_req: Request, file: Express.Multer.File, cb: FileFilterCall
   }
 };
 
-const upload = multer({
-  storage: storage,
-  limits: {
-    fileSize: 1024 * 1024 * 5 // 5MB
-  },
-  fileFilter: fileFilter
+const baseUpload = multer({
+  storage,
+  limits: { fileSize: 1024 * 1024 * 5 }, // 5MB
+  fileFilter,
 });
 
-// Upload de foto do profissional (campo "photo")
-export const uploadProfessionalPhoto = upload.single('photo');
+function createSingleUploader(field: string) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const handler = baseUpload.single(field);
+    handler(req, res, async (err: any) => {
+      if (err) return next(err);
+      if (req.file) {
+        try {
+          const path = await uploadImageFromBuffer(req.file.buffer, req.file.mimetype);
+          req.file.filename = path;
+        } catch (e) {
+          return next(e);
+        }
+      }
+      next();
+    });
+  };
+}
 
-// Upload de foto do paciente (campo "photo")
-export const uploadPatientPhoto = upload.single('photo');
+function createFieldsUploader(fields: multer.Field[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const handler = baseUpload.fields(fields);
+    handler(req, res, async (err: any) => {
+      if (err) return next(err);
+      const files = req.files as { [fieldname: string]: Express.Multer.File[] };
+      const tasks: Promise<void>[] = [];
+      Object.values(files || {}).forEach(list => {
+        list.forEach(file => {
+          tasks.push(
+            uploadImageFromBuffer(file.buffer, file.mimetype).then(path => {
+              file.filename = path;
+            })
+          );
+        });
+      });
+      try {
+        await Promise.all(tasks);
+        next();
+      } catch (e) {
+        next(e);
+      }
+    });
+  };
+}
 
-// Uploads da clínica (capa e galeria)
-export const uploadClinicImages = upload.fields([
+export const uploadProfessionalPhoto = createSingleUploader('photo');
+export const uploadPatientPhoto = createSingleUploader('photo');
+export const uploadProcedureImage = createSingleUploader('procedureImage');
+export const uploadClinicImages = createFieldsUploader([
   { name: 'coverImage', maxCount: 1 },
-  { name: 'galleryImages', maxCount: 10 }
+  { name: 'galleryImages', maxCount: 10 },
 ]);
 
-// Upload de imagem de procedimento individual (campo "procedureImage")
-export const uploadProcedureImage = upload.single('procedureImage');
-
-export default upload;
+export default baseUpload;

--- a/backend/src/routes/patients.ts
+++ b/backend/src/routes/patients.ts
@@ -28,7 +28,7 @@ router.post(
       if (!req.file) {
         return res.status(400).json({ error: "Nenhum arquivo enviado." });
       }
-      const fileUrl = `/uploads/${req.file.filename}`;
+      const fileUrl = req.file.filename;
       res.json({ url: fileUrl, filename: req.file.filename });
     });
   }

--- a/backend/src/services/clinicFullService.ts
+++ b/backend/src/services/clinicFullService.ts
@@ -263,7 +263,7 @@ export async function updateClinicSettings(
   // Se veio imagem de capa pelo Multer, sobrescreva
   if (files && files.coverImage && files.coverImage.length > 0) {
     const file = files.coverImage[0];
-    updateData.cover_image_url = `/uploads/${file.filename}`;
+    updateData.cover_image_url = file.filename;
   }
 
   // Se vieram imagens de galeria pelo Multer, adicione/concatene corretamente
@@ -278,7 +278,7 @@ export async function updateClinicSettings(
         currentGallery = [];
       }
     }
-    const newImages = files.galleryImages.map((file: any) => `/uploads/${file.filename}`);
+    const newImages = files.galleryImages.map((file: any) => file.filename);
     const finalGallery = [...currentGallery, ...newImages];
     updateData.gallery_image_urls = JSON.stringify(finalGallery);
   } else if (data.galleryUrls) {

--- a/backend/src/services/storageService.ts
+++ b/backend/src/services/storageService.ts
@@ -1,0 +1,34 @@
+import { supabase } from "../supabaseClient";
+import { randomUUID } from "crypto";
+
+const BUCKET = process.env.SUPABASE_STORAGE_BUCKET || "avatars";
+
+export async function uploadImageFromBuffer(buffer: Buffer, mime: string): Promise<string> {
+  const ext = (() => {
+    const e = mime.split("/")[1] || "png";
+    return e === "jpeg" ? "jpg" : e;
+  })();
+  const fileName = `img-${Date.now()}-${randomUUID()}.${ext}`;
+  const { error } = await supabase.storage.from(BUCKET).upload(fileName, buffer, {
+    contentType: mime,
+    upsert: false,
+  });
+  if (error) throw error;
+  return `${BUCKET}/${fileName}`;
+}
+
+export async function uploadImageFromDataUrl(dataUrl: string): Promise<string> {
+  const match = dataUrl.match(/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/);
+  if (!match) throw new Error("Data URL inválida");
+  const mime = match[1];
+  const b64 = match[2];
+  const buf = Buffer.from(b64, "base64");
+  return uploadImageFromBuffer(buf, mime);
+}
+
+export async function removeImage(path: string): Promise<void> {
+  const [bucket, ...rest] = path.split("/");
+  const filePath = rest.join("/");
+  if (!bucket || !filePath) return;
+  await supabase.storage.from(bucket).remove([filePath]);
+}

--- a/frontend/src/utils/normalizeProfessional.ts
+++ b/frontend/src/utils/normalizeProfessional.ts
@@ -1,11 +1,5 @@
 import type { Professional } from "@/components/ClinicAdminPanel_Managers/types";
-
-// Ajuste este helper conforme sua implementação real de resolver imagens
-export function resolveImageUrl(raw: string | undefined | null): string | undefined {
-  if (!raw) return undefined;
-  if (raw.startsWith("http")) return raw;
-  return `/uploads/${raw}`; // Exemplo
-}
+import { resolveImageUrl } from "@/utils/resolveImage";
 
 export function normalizeProfessional(raw: any): Professional {
   const id = Number(raw.id);


### PR DESCRIPTION
## Summary
- Persist uploaded files using Supabase Storage instead of local disk
- Update professional, patient, and clinic image handlers to work with storage paths
- Normalize professional photos via shared image resolver

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68b051d9b218833088525e303097d81a